### PR TITLE
Possible fix for nightmode bug

### DIFF
--- a/ZIGBEE_HELPERS.ino
+++ b/ZIGBEE_HELPERS.ino
@@ -42,7 +42,7 @@ delayMicroseconds(250);
             if (readCounter < CC2530_MAX_SERIAL_BUFFER_SIZE)
             {
                 processIncomingByte(Serial.read());
-                readCounter += 1;
+                readCounter += 2;
             }
             else
             {


### PR DESCRIPTION
Buffer overflow; processIncomingByte adds 2 bytes to inMessage which is overflowing on big messages when doing += 1 instead of +=2.

I could not reproduce the bug after this fix. 

https://github.com/patience4711/read-APS-inverters-YC600-QS1/issues/7